### PR TITLE
README: Add ORT's spdx-utils expression parser

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@
 | Document | [spdx/tools-python](https://github.com/spdx/tools-python) | Python |
 | Document | [ah450/spdx-tools-python](https://github.com/ah450/spdx-tools-python) | Python |
 | Expression | [nexB/license-expression](https://github.com/nexB/license-expression) | Python |
+| Expression | [heremaps/oss-review-toolkit](https://github.com/heremaps/oss-review-toolkit/tree/master/spdx-utils) | Kotlin (Java) |
 
 ## Other Tools
 


### PR DESCRIPTION
Add the OSS Review Toolkit's expression parser even if it's only available
as source code for now (binary artifacts will be published soon) as it's
quite capable.